### PR TITLE
Rename OAuth endpoints to match RFC6749

### DIFF
--- a/index.html
+++ b/index.html
@@ -670,14 +670,23 @@
             with the value being the <code>id</code> of the requested
             ActivityStreams object.
           </dd>
-          <dt id="oauthClientAuthorize">oauthClientAuthorize</dt>
+          <dt id="oauthAuthorizationEndpoint">oauthAuthorizationEndpoint</dt>
           <dd>
             If OAuth 2.0 bearer tokens [[RFC6749]] [[RFC6750]] are being used
             for authenticating
             <a href="#client-to-server-interactions">client to server
               interactions</a>,
             this endpoint specifies a URI at which a browser-authenticated user
-            may obtain a new access token.
+            may obtain a new authorization grant.
+          </dd>
+          <dt id="oauthTokenEndpoint">oauthTokenEndpoint</dt>
+          <dd>
+            If OAuth 2.0 bearer tokens [[RFC6749]] [[RFC6750]] are being used
+            for authenticating
+            <a href="#client-to-server-interactions">client to server
+              interactions</a>,
+            this endpoint specifies a URI at which a client may acquire an
+	    access token.
           </dd>
           <dt id="provideClientKey">provideClientKey</dt>
           <dd>


### PR DESCRIPTION
I REALLY am not confident that the text here makes sense so cc @aaronpk for a quick sanity check

Fixes #191