### PR TITLE
fix copy pasta typo in Announce Activity section, likes => shares

### DIFF
--- a/index.html
+++ b/index.html
@@ -2205,7 +2205,7 @@ Location: https://dustycloud.org/likes/345
         <p>
           Upon receipt of an <code>Announce</code> activity in an
           <strong>inbox</strong>, a server SHOULD increment the object's count
-          of likes by adding the received activity to the
+          of shares by adding the received activity to the
           <a href="#shares"><code>shares</code></a> collection
           if this collection is present.
         </p>


### PR DESCRIPTION
i think this is right? not sure. feel free to reject!