### PR TITLE
Fix typo in Linked Data Notifications callout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1811,7 +1811,7 @@ Location: https://dustycloud.org/likes/345
           it is worth noting that ActivityPub's targeting and delivery
           mechanism overlaps with the
           <a href="https://www.w3.org/TR/ldn/">Linked Data Notifications</a>
-          specification, and the two specifications may interoperably
+          specification, and the two specifications may be interoperably
           combined.
           In particular, the <code>inbox</code> property is the same between
           ActivityPub and Linked Data Notifications, and the targeting


### PR DESCRIPTION
I don't think the sentence:

> While it is not required reading to understand this specification, it is worth noting that ActivityPub's targeting and delivery mechanism overlaps with the Linked Data Notifications specification, and the two specifications may interoperably combined.

scans properly.

I think:

> the two specifications may interoperably combined

should read

> the two specifications may be interoperably combined

?