### PR TITLE
Add "MUST" to required Object types

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,7 +558,7 @@
           allocate an object ID in the actor's namespace and attach it to the
           posted object.
         </p>
-        <p>All objects have the following properties:</p>
+        <p>All objects MUST have the following properties:</p>
         <dl>
           <dt>id</dt>
           <dd>


### PR DESCRIPTION
There is a discussion to be had here about `type`, which is _optional_ in ActivityStreams Core ("All properties are optional (including the id and type)."), however it is unclear what ActivityPub would do with Objects lacking `type` and so probably clearer to just make it mandatory.