### PR TITLE
Fix typos raised in WG readthrough

### DIFF
--- a/index.html
+++ b/index.html
@@ -688,7 +688,7 @@
           <dt id="following-property">following</dt>
           <dd>
             A link to an [[!activitystreams-core]] collection of the actors that
-            this actor is following; see <a href="#following"></a>
+            this actor is following; see <a href="#following"></a>.
           </dd>
           <dt id="followers-property">followers</dt>
           <dd>
@@ -738,7 +738,7 @@
           </dd>
           <dt id="endpoints">endpoints</dt>
           <dd>
-            A json object which maps additional (typically server/domain-wide)
+            A JSON object which maps additional (typically server/domain-wide)
             endpoints which may be useful either for this actor or someone
             referencing this actor.
             This mapping may be nested inside the actor document as the value


### PR DESCRIPTION
Per https://hedgedoc.socialweb.coop/AePwJKbMQFC7tDsCWY6Pew?both

- missing period in dfn of `following`
- capitalization of JSON in dfn of `endpoints`